### PR TITLE
Make highlight duration configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Moving slowly, showing each command
 {
   "aaronik/treewalker.nvim",
   opts = {
-    highlight = true -- default is false
+    highlight = true -- default is false; can also be a duration
   }
 }
 ```

--- a/lua/treewalker/init.lua
+++ b/lua/treewalker/init.lua
@@ -6,7 +6,7 @@ local strategies = require('treewalker.strategies')
 
 local Treewalker = {}
 
----@alias Opts { highlight: boolean }
+---@alias Opts { highlight: boolean | integer }
 
 ---@type Opts
 Treewalker.opts = {}

--- a/lua/treewalker/ops.lua
+++ b/lua/treewalker/ops.lua
@@ -25,7 +25,8 @@ end
 
 ---Flash a highlight over the given range
 ---@param range Range4
-function M.highlight(range)
+---@param duration integer
+function M.highlight(range, duration)
   local start_row, start_col, end_row, end_col = range[1], range[2], range[3], range[4]
   local ns_id = vim.api.nvim_create_namespace("")
   -- local hl_group = "DiffAdd"
@@ -52,7 +53,7 @@ function M.highlight(range)
 
   vim.defer_fn(function()
     vim.api.nvim_buf_clear_namespace(0, ns_id, 0, -1)
-  end, 250)
+  end, duration)
 end
 
 ---@param row integer
@@ -62,8 +63,9 @@ function M.jump(row, node)
   -- log(row, line, node)
   vim.api.nvim_win_set_cursor(0, { row, 0 })
   vim.cmd('normal! ^')
-  if require("treewalker").opts.highlight then
-    M.highlight(nodes.range(node))
+  local highlight = require("treewalker").opts.highlight
+  if highlight and highlight ~= 0 then
+    M.highlight(nodes.range(node), highlight ~= true and highlight or 250)
   end
 end
 

--- a/tests/treewalker/acceptance_spec.lua
+++ b/tests/treewalker/acceptance_spec.lua
@@ -22,13 +22,11 @@ end
 ---@param fn unknown
 ---@param expected_duration integer
 local function assert_called_after(fn, expected_duration)
-  ---@diagnostic disable: undefined-field
   fn:clear()
   local tolerance = 5
-  local start = vim.loop.hrtime()
+  local start = vim.uv.hrtime()
   vim.wait(expected_duration + tolerance * 2, function() return #fn.calls == 1 end, tolerance / 2)
-  assert(math.abs((vim.loop.hrtime() - start) / 1000000 - expected_duration) < tolerance)
-  ---@diagnostic enable: undefined-field
+  assert(math.abs((vim.uv.hrtime() - start) / 1000000 - expected_duration) < tolerance)
 end
 
 describe("Treewalker", function()

--- a/tests/treewalker/acceptance_spec.lua
+++ b/tests/treewalker/acceptance_spec.lua
@@ -1,6 +1,6 @@
 local util = require "treewalker.util"
 local load_fixture = require "tests.load_fixture"
-local stub = require 'luassert.stub'
+local spy = require 'luassert.spy'
 local assert = require "luassert"
 local treewalker = require 'treewalker'
 local ops = require 'treewalker.ops'
@@ -16,19 +16,6 @@ local function assert_cursor_at(line, column, msg)
   current_line, current_column = cursor_pos[2], cursor_pos[3]
   msg = string.format("expected to be at [%s] but wasn't", msg)
   assert.are.same({ line, column }, { current_line, current_column }, msg)
-end
-
--- Count the number of calls made against the stub after a specified duration
----@param api unknown
----@param duration integer
----@return integer
-local function calls_after(api, duration)
-  local tolerance = 5
-  local calls = #api.calls
-  vim.wait(duration - tolerance)
-  assert.equal(0, #api.calls - calls)
-  vim.wait(tolerance * 2)
-  return #api.calls - calls
 end
 
 describe("Treewalker", function()
@@ -92,7 +79,18 @@ describe("Treewalker", function()
     end)
 
     it("respects highlight config option", function()
-      local highlight_stub = stub(ops, "highlight")
+      spy.on(ops, "highlight")
+      local bufclear = spy.on(vim.api, "nvim_buf_clear_namespace")
+
+      -- 'nvim_buf_clear_namespace' should be called <calls> times
+      -- within a 10ms tolerance window after <timeout>ms
+      local function assert_bufclears_after(timeout, calls)
+        bufclear:clear()
+        vim.wait(timeout - 5)
+        assert.spy(bufclear).was.not_called()
+        vim.wait(10)
+        assert.spy(bufclear).was.called(calls)
+      end
 
       treewalker.setup()
       vim.fn.cursor(23, 5)
@@ -100,7 +98,7 @@ describe("Treewalker", function()
       treewalker.move_down()
       treewalker.move_up()
       treewalker.move_in()
-      assert.equal(0, #highlight_stub.calls)
+      assert.spy(ops.highlight).was.not_called()
 
       treewalker.setup({ highlight = 0 })
       vim.fn.cursor(23, 5)
@@ -108,7 +106,7 @@ describe("Treewalker", function()
       treewalker.move_down()
       treewalker.move_up()
       treewalker.move_in()
-      assert.equal(0, #highlight_stub.calls)
+      assert.spy(ops.highlight).was.not_called()
 
       treewalker.setup({ highlight = false })
       vim.fn.cursor(23, 5)
@@ -116,7 +114,7 @@ describe("Treewalker", function()
       treewalker.move_down()
       treewalker.move_up()
       treewalker.move_in()
-      assert.equal(0, #highlight_stub.calls)
+      assert.spy(ops.highlight).was.not_called()
 
       treewalker.setup({ highlight = true })
       vim.fn.cursor(23, 5)
@@ -124,18 +122,8 @@ describe("Treewalker", function()
       treewalker.move_down()
       treewalker.move_up()
       treewalker.move_in()
-      assert.equal(4, #highlight_stub.calls)
-
-      highlight_stub:revert()
-      local clear_stub = stub(vim.api, "nvim_buf_clear_namespace")
-
-      treewalker.setup({ highlight = true })
-      vim.fn.cursor(23, 5)
-      treewalker.move_out()
-      treewalker.move_down()
-      treewalker.move_up()
-      treewalker.move_in()
-      assert.equal(4, calls_after(clear_stub, 250))
+      assert.spy(ops.highlight).was.called(4)
+      assert_bufclears_after(250, 4)
 
       treewalker.setup({ highlight = 50 })
       vim.fn.cursor(23, 5)
@@ -143,7 +131,8 @@ describe("Treewalker", function()
       treewalker.move_down()
       treewalker.move_up()
       treewalker.move_in()
-      assert.equal(4, calls_after(clear_stub, 50))
+      assert.spy(ops.highlight).was.called(8)
+      assert_bufclears_after(50, 4)
 
       treewalker.setup({ highlight = 500 })
       vim.fn.cursor(23, 5)
@@ -151,7 +140,8 @@ describe("Treewalker", function()
       treewalker.move_down()
       treewalker.move_up()
       treewalker.move_in()
-      assert.equal(4, calls_after(clear_stub, 500))
+      assert.spy(ops.highlight).was.called(12)
+      assert_bufclears_after(500, 4)
     end)
   end)
 

--- a/tests/treewalker/acceptance_spec.lua
+++ b/tests/treewalker/acceptance_spec.lua
@@ -18,15 +18,17 @@ local function assert_cursor_at(line, column, msg)
   assert.are.same({ line, column }, { current_line, current_column }, msg)
 end
 
--- Assert the stub is called after the expected duration
----@param fn unknown
----@param expected_duration integer
-local function assert_called_after(fn, expected_duration)
-  fn:clear()
+-- Count the number of calls made against the stub after a specified duration
+---@param api unknown
+---@param duration integer
+---@return integer
+local function calls_after(api, duration)
   local tolerance = 5
-  local start = vim.uv.hrtime()
-  vim.wait(expected_duration + tolerance * 2, function() return #fn.calls == 1 end, tolerance / 2)
-  assert(math.abs((vim.uv.hrtime() - start) / 1000000 - expected_duration) < tolerance)
+  local calls = #api.calls
+  vim.wait(duration - tolerance)
+  assert.equal(0, #api.calls - calls)
+  vim.wait(tolerance * 2)
+  return #api.calls - calls
 end
 
 describe("Treewalker", function()
@@ -130,17 +132,26 @@ describe("Treewalker", function()
       treewalker.opts.highlight = true
       vim.fn.cursor(23, 5)
       treewalker.move_out()
-      assert_called_after(clear_stub, 250)
+      treewalker.move_down()
+      treewalker.move_up()
+      treewalker.move_in()
+      assert.equal(4, calls_after(clear_stub, 250))
 
       treewalker.opts.highlight = 50
       vim.fn.cursor(23, 5)
       treewalker.move_out()
-      assert_called_after(clear_stub, 50)
+      treewalker.move_down()
+      treewalker.move_up()
+      treewalker.move_in()
+      assert.equal(4, calls_after(clear_stub, 50))
 
       treewalker.opts.highlight = 500
       vim.fn.cursor(23, 5)
       treewalker.move_out()
-      assert_called_after(clear_stub, 500)
+      treewalker.move_down()
+      treewalker.move_up()
+      treewalker.move_in()
+      assert.equal(4, calls_after(clear_stub, 500))
     end)
   end)
 


### PR DESCRIPTION
Hi,
Thank you for this excellent plug-in!

I like the highlighting, but would want it a bit snappier.

This PR answers that concern by letting `opts.highlight` be a `boolean | integer`. I don't know what you think about that; it could also be a separate property, and I'd be happy to make any changes.

The highlighting is now cleared after the duration defined by that value, or `250` by default—as you had originally set it up to be.

The table below illustrates the upgraded behaviour:

| opts.highlight  |       behaviour      |
|-----------------|----------------------|
| `nil`             |  no highlighting     |
| `false`           |  no highlighting     |
| `0`               |  no highlighting     |
| `true`            |  highlight for `250ms` |
| `n` where `n > 0`   |  highlight for `<n>ms` |

Fixes https://github.com/aaronik/treewalker.nvim/issues/5.