### PR TITLE
Highlight farthest coinciding ancestor

### DIFF
--- a/lua/treewalker/nodes.lua
+++ b/lua/treewalker/nodes.lua
@@ -15,6 +15,13 @@ local TARGET_DESCENDANT_TYPES = {
   "do_block", -- rb
 }
 
+local HIGHLIGHT_BLACKLIST_TYPES = {
+  "body_statement",  -- lua, rb
+  "block",           -- lua
+  "statement_block", -- lua
+  "program",         -- rb
+}
+
 local M = {}
 
 ---@param node TSNode
@@ -31,6 +38,10 @@ end
 
 function M.is_descendant_jump_target(node)
   return util.contains(TARGET_DESCENDANT_TYPES, node:type())
+end
+
+function M.is_highlight_target(node)
+  return util.contains(HIGHLIGHT_BLACKLIST_TYPES, node:type())
 end
 
 ---Do the nodes have the same starting point

--- a/lua/treewalker/ops.lua
+++ b/lua/treewalker/ops.lua
@@ -66,7 +66,7 @@ function M.jump(row, node)
     -- Get farthest ancestor (or self) at the same starting coordinates
     local parent = node:parent()
     while parent and nodes.have_same_start(node, parent) do
-      if nodes.is_jump_target(parent) then node = parent end
+      if nodes.is_highlight_target(parent) then node = parent end
       parent = parent:parent()
     end
     M.highlight(nodes.range(node))

--- a/lua/treewalker/ops.lua
+++ b/lua/treewalker/ops.lua
@@ -63,6 +63,12 @@ function M.jump(row, node)
   vim.api.nvim_win_set_cursor(0, { row, 0 })
   vim.cmd('normal! ^')
   if require("treewalker").opts.highlight then
+    -- Get farthest ancestor (or self) at the same starting coordinates
+    local parent = node:parent()
+    while parent and nodes.have_same_start(node, parent) do
+      if nodes.is_jump_target(parent) then node = parent end
+      parent = parent:parent()
+    end
     M.highlight(nodes.range(node))
   end
 end

--- a/lua/treewalker/strategies.lua
+++ b/lua/treewalker/strategies.lua
@@ -20,6 +20,16 @@ local function get_node_from_neighboring_line(current_row, dir)
   local candidate_line = lines.get_line(candidate_row)
   local candidate_col = lines.get_start_col(candidate_line)
   local candidate = nodes.get_at_rowcol(candidate_row, candidate_col)
+
+  -- Get farthest ancestor _which starts at the same coordinates as the candidate_
+  if candidate then
+    local next = candidate:parent()
+    while next and nodes.have_same_start(candidate, next) do
+      if nodes.is_jump_target(next) then candidate = next end
+      next = next:parent()
+    end
+  end
+
   return candidate, candidate_row, candidate_line
 end
 

--- a/lua/treewalker/strategies.lua
+++ b/lua/treewalker/strategies.lua
@@ -20,16 +20,6 @@ local function get_node_from_neighboring_line(current_row, dir)
   local candidate_line = lines.get_line(candidate_row)
   local candidate_col = lines.get_start_col(candidate_line)
   local candidate = nodes.get_at_rowcol(candidate_row, candidate_col)
-
-  -- Get farthest ancestor _which starts at the same coordinates as the candidate_
-  if candidate then
-    local next = candidate:parent()
-    while next and nodes.have_same_start(candidate, next) do
-      if nodes.is_jump_target(next) then candidate = next end
-      next = next:parent()
-    end
-  end
-
   return candidate, candidate_row, candidate_line
 end
 


### PR DESCRIPTION
This PR proposes to implement the selection of the outermost ancestor to the jump node that:
- is valid
- shares starting coordinates with the jump node

This implementation only bothers with computing the "ideally" selected node when highlighting is activated.

Here's a screencast of the fixed behaviour in action:
[![asciicast](https://asciinema.org/a/ttigJi4EmqKkGZ23gw7DDJZKS.svg)](https://asciinema.org/a/ttigJi4EmqKkGZ23gw7DDJZKS)

This fixes https://github.com/aaronik/treewalker.nvim/issues/8.