### PR TITLE
Add swap next and swap previous node

### DIFF
--- a/lua/treewalker/init.lua
+++ b/lua/treewalker/init.lua
@@ -4,6 +4,8 @@ local ops = require('treewalker.ops')
 local lines = require('treewalker.lines')
 local strategies = require('treewalker.strategies')
 
+local ts_utils = require 'nvim-treesitter.ts_utils'
+
 local Treewalker = {}
 
 ---@alias Opts { highlight: boolean }
@@ -99,6 +101,32 @@ function Treewalker.move_down()
 
   -- Ultimate failure
   return --util.log("no down candidate")
+end
+
+---@return nil
+function Treewalker.swap_prev()
+  local node = strategies.get_current_top_node()
+  if not node then
+    return
+  end
+
+  local prev_node = node:prev_named_sibling()
+  if prev_node then
+    ts_utils.swap_nodes(node, prev_node, 0, true)
+  end
+end
+
+---@return nil
+function Treewalker.swap_next()
+  local node = strategies.get_current_top_node()
+  if not node then
+    return
+  end
+
+  local next_node = node:next_named_sibling()
+  if next_node then
+    ts_utils.swap_nodes(node, next_node, 0, true)
+  end
 end
 
 return Treewalker

--- a/lua/treewalker/nodes.lua
+++ b/lua/treewalker/nodes.lua
@@ -4,6 +4,7 @@ local lines= require "treewalker.lines"
 local NON_TARGET_NODE_MATCHERS = {
   -- "chunk", -- lua
   "^.*comment.*$",
+  "block"
 }
 
 local TARGET_DESCENDANT_TYPES = {

--- a/lua/treewalker/strategies.lua
+++ b/lua/treewalker/strategies.lua
@@ -2,9 +2,6 @@ local lines = require('treewalker.lines')
 local nodes = require('treewalker.nodes')
 local util  = require('treewalker.util')
 
-local parsers = require "nvim-treesitter.parsers"
-local ts_utils = require 'nvim-treesitter.ts_utils'
-
 ---@alias Dir "up" | "down"
 
 -- Take row, give next row / node with same indentation
@@ -193,7 +190,7 @@ function M.get_current_top_node()
     return search_parent(parent, depth - 1)
   end
 
-  local node = ts_utils.get_node_at_cursor(0)
+  local node = vim.treesitter.get_node()
 
   if not node then
     return nil

--- a/lua/treewalker/strategies.lua
+++ b/lua/treewalker/strategies.lua
@@ -185,7 +185,7 @@ function M.get_current_top_node()
     local parent_start_row, parent_start_col = parent:range()
 
     -- If the node does not start at the same position as its parent, return the node
-    if start_row ~= parent_start_row or start_col ~= parent_start_col then
+    if start_row ~= parent_start_row or start_col ~= parent_start_col or not nodes.is_jump_target(parent) then
         return node
     end
 


### PR DESCRIPTION
Nice plugin! The code is well-organized. 

I've had similar code in my dot file for a while, but I haven't had time to refactor it into a plugin. So, I think it would be better to contribute to yours instead of writing my own.

My solution is based on a concept called the **current top node**. I use the topmost node starting at my current cursor as the starting point. This allows me to easily navigate to the next Tree-sitter neighbour by calling "next_named_sibling()" on the current top node. It also lets me swap the node using Tree-sitter utility functions.

This can help to solve the issue https://github.com/aaronik/treewalker.nvim/issues/4

Demo:
[![asciicast](https://asciinema.org/a/PhpuZLywiF3HSHGLAZ35PEFvu.svg)](https://asciinema.org/a/PhpuZLywiF3HSHGLAZ35PEFvu)


I think there might be various strategies for navigating the Tree-sitter node tree beyond yours and mine. It would be wonderful to give users the option to configure it based on their preferences.
