### PR TITLE
refactor: replace util.contains & util.merge_tables with builtin func…

### DIFF
--- a/lua/treewalker/init.lua
+++ b/lua/treewalker/init.lua
@@ -1,5 +1,4 @@
 local nodes = require('treewalker.nodes')
-local util = require('treewalker.util')
 local ops = require('treewalker.ops')
 local lines = require('treewalker.lines')
 local strategies = require('treewalker.strategies')
@@ -17,7 +16,7 @@ Treewalker.opts = {
 
 ---@param opts Opts | nil
 function Treewalker.setup(opts)
-  Treewalker.opts = util.merge_tables(Treewalker.opts, opts)
+  Treewalker.opts = vim.tbl_deep_extend('force', Treewalker.opts, opts or {})
 end
 
 ---@return nil

--- a/lua/treewalker/strategies.lua
+++ b/lua/treewalker/strategies.lua
@@ -1,6 +1,5 @@
 local lines = require('treewalker.lines')
 local nodes = require('treewalker.nodes')
-local util  = require('treewalker.util')
 
 ---@alias Dir "up" | "down"
 

--- a/lua/treewalker/util.lua
+++ b/lua/treewalker/util.lua
@@ -55,42 +55,6 @@ M.log = function(...)
   log_file:close()
 end
 
----@param lines string[]
----@param string string
-M.contains = function(lines, string)
-  local found_line = false
-  for _, line in ipairs(lines) do
-    if line == string then
-      found_line = true
-      break
-    end
-  end
-  return found_line
-end
-
---- Merging multiple tables into one. Works on both map like and array like tables.
---- This function accepts variadic arguments (multiple tables)
---- It merges keys from the provided tables into a new table.
---- Later tables get precedence
---- @generic T
---- @param ... T - Any number of tables to merge.
---- @return T - A new merged table of the same type as the input tables.
-M.merge_tables = function(...)
-  local new_table = {}
-
-  for _, t in ipairs({ ... }) do
-    for k, v in pairs(t) do
-      if type(k) == "number" then
-        table.insert(new_table, v)
-      else
-        new_table[k] = v
-      end
-    end
-  end
-
-  return new_table
-end
-
 M.guid = function()
   local template = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'
   return string.gsub(template, '[xy]', function(c)

--- a/tests/fixtures/lua.lua
+++ b/tests/fixtures/lua.lua
@@ -1,5 +1,3 @@
-local util = require('treewalker.util')
-
 local M = {}
 
 local NON_TARGET_NODE_MATCHERS = {
@@ -28,7 +26,7 @@ local function is_jump_target(node)
 end
 
 local function is_descendant_jump_target(node)
-  return util.contains(TARGET_DESCENDANT_TYPES, node:type())
+  return vim.list_contains(TARGET_DESCENDANT_TYPES, node:type())
 end
 
 ---Do the nodes have the same starting point

--- a/tests/treewalker/util_spec.lua
+++ b/tests/treewalker/util_spec.lua
@@ -3,11 +3,6 @@ local stub = require('luassert.stub')
 local assert = require("luassert")
 
 describe("util", function()
-  describe("contains_line", function()
-    assert(util.contains({ "has", "also" }, "has"))
-    assert.False(util.contains({ "doesnt" }, "has"))
-  end)
-
   describe("guid", function()
     it("never repeats", function()
       local guids = {}
@@ -54,40 +49,6 @@ describe("util", function()
       assert.same({ "1\n", "2\n", "3\n", "4\n", "5\n", }, writes)
       assert.equal(1, num_flushes)
       assert.equal(1, num_closes)
-    end)
-  end)
-
-  describe("merge_tables", function()
-    it("merges N hash style tables", function()
-      local a = { a = true }
-      local b = { b = true }
-      local c = { c = true }
-      local d = util.merge_tables(a, b, c)
-      assert.same({ a = true, b = true, c = true }, d)
-    end)
-
-    it("merges multiple array style tables", function()
-      local a = { true }
-      local b = { false }
-      local c = { true, false }
-      local d = util.merge_tables(a, b, c)
-      assert.same({ true, false, true, false }, d)
-    end)
-
-    it("merges combo style tables", function()
-      local a = { a = true }
-      local b = { false, false }
-      local c = { true, true }
-      local d = util.merge_tables(a, b, c)
-      assert.same({ a = true, false, false, true, true }, d)
-    end)
-
-    it("does not overwrite arguments", function()
-      local a = { a = true }
-      local b = { b = true }
-      util.merge_tables(a, b)
-      assert.same({ a = true }, a)
-      assert.same({ b = true }, b)
     end)
   end)
 


### PR DESCRIPTION
Hi, I noticed there are some util functions are already built-in, we don't have to implement it again.

`util.reverse` can be replaced with `vim.fn.reverse` or `vim.iter(list):rev():totable()`