### PR TITLE
Add new option 'highlight_group'

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The swap commands intelligently swap nodes, including comments and attributes/de
   opts = {
     highlight = true, -- Whether to briefly highlight the node after jumping to it
     highlight_duration = 250, -- How long should above highlight last (in ms)
+    highlight_group = "ColorColumn", -- Highlight group 
   }
 }
 ```

--- a/lua/treewalker/init.lua
+++ b/lua/treewalker/init.lua
@@ -9,28 +9,28 @@ local Treewalker = {}
 -- Default setup() options
 ---@type Opts
 Treewalker.opts = {
-	highlight = true,
-	highlight_duration = 250,
-	highlight_group = "ColorColumn",
+  highlight = true,
+  highlight_duration = 250,
+  highlight_group = "ColorColumn",
 }
 
 ---@param opts Opts | nil
 function Treewalker.setup(opts)
-	if opts then
+  if opts then
     Treewalker.opts = vim.tbl_deep_extend('force', Treewalker.opts, opts)
-	end
+  end
 end
 
 -- TODO This is clever kinda, but it breaks autocomplete of `require('treewalker')`
 
 -- Assign move_{in,out,up,down}
 for fn_name, fn in pairs(movement) do
-	Treewalker[fn_name] = fn
+  Treewalker[fn_name] = fn
 end
 
 -- Assign swap_{up,down}
 for fn_name, fn in pairs(swap) do
-	Treewalker[fn_name] = fn
+  Treewalker[fn_name] = fn
 end
 
 return Treewalker

--- a/lua/treewalker/init.lua
+++ b/lua/treewalker/init.lua
@@ -9,27 +9,28 @@ local Treewalker = {}
 -- Default setup() options
 ---@type Opts
 Treewalker.opts = {
-  highlight = true,
-  highlight_duration = 250,
+	highlight = true,
+	highlight_duration = 250,
+	highlight_group = "ColorColumn",
 }
 
 ---@param opts Opts | nil
 function Treewalker.setup(opts)
-  if opts then
+	if opts then
     Treewalker.opts = vim.tbl_deep_extend('force', Treewalker.opts, opts)
-  end
+	end
 end
 
 -- TODO This is clever kinda, but it breaks autocomplete of `require('treewalker')`
 
 -- Assign move_{in,out,up,down}
 for fn_name, fn in pairs(movement) do
-  Treewalker[fn_name] = fn
+	Treewalker[fn_name] = fn
 end
 
 -- Assign swap_{up,down}
 for fn_name, fn in pairs(swap) do
-  Treewalker[fn_name] = fn
+	Treewalker[fn_name] = fn
 end
 
 return Treewalker

--- a/lua/treewalker/ops.lua
+++ b/lua/treewalker/ops.lua
@@ -13,7 +13,7 @@ local M = {}
 function M.highlight(range, duration)
   local start_row, start_col, end_row, end_col = range[1], range[2], range[3], range[4]
   local ns_id = vim.api.nvim_create_namespace("")
-  local hl_group = "ColorColumn"
+  local hl_group = require("treewalker").opts.highlight_group
 
   for row = start_row, end_row do
     if row == start_row and row == end_row then


### PR DESCRIPTION
Hi! Thanks for the amazing plugin; navigating the code has become even more convenient. However, I have an issue. The highlight group you chose for highlighting moving objects conflicts with my configuration. Another plugin [overwrites it](https://github.com/lukas-reineke/virt-column.nvim/blob/master/lua/virt-column/init.lua#L11), and there's nothing I can do about it. Could you please accept my PR that adds a new option to your plugin, allowing the highlight group to be customized? I would be very happy :)