### PR TITLE
Add selection commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ and then feel lost, you always have `Ctrl-o` available to bring you back to wher
 
 ---
 
+## Selection
+
+The selection commands are similar to the movement commands, but the node is automatically selected:
+
+* **`:Treewalker SelectUp`** - Moves up to the previous neighbor node, and selects it
+* **`:Treewalker SelectDown`** - Moves down to the next neighbor node, and selects it
+* **`:Treewalker SelectLeft`** - Moves to the first ancestor node that's on a different line from the current node, and selects it
+* **`:Treewalker SelectRight`** - Moves to the next node down that's indented further than the current node, and selects it
+
+---
+
 ## Swapping
 
 `Swap{Up,Down}` operate on a linewise basis, and **bring along their comments, decorators, and annotations**.
@@ -143,6 +154,12 @@ vim.keymap.set({ 'n', 'v' }, '<C-k>', '<cmd>Treewalker Up<cr>', { silent = true 
 vim.keymap.set({ 'n', 'v' }, '<C-j>', '<cmd>Treewalker Down<cr>', { silent = true })
 vim.keymap.set({ 'n', 'v' }, '<C-h>', '<cmd>Treewalker Left<cr>', { silent = true })
 vim.keymap.set({ 'n', 'v' }, '<C-l>', '<cmd>Treewalker Right<cr>', { silent = true })
+
+-- selection
+vim.keymap.set('n', '<C-M-k>', '<cmd>Treewalker SelectUp<cr>', { silent = true })
+vim.keymap.set('n', '<C-M-j>', '<cmd>Treewalker SelectDown<cr>', { silent = true })
+vim.keymap.set('n', '<C-M-h>', '<cmd>Treewalker SelectLeft<cr>', { silent = true })
+vim.keymap.set('n', '<C-M-l>', '<cmd>Treewalker SelectRight<cr>', { silent = true })
 
 -- swapping
 vim.keymap.set('n', '<C-S-k>', '<cmd>Treewalker SwapUp<cr>', { silent = true })

--- a/lua/treewalker/init.lua
+++ b/lua/treewalker/init.lua
@@ -50,6 +50,11 @@ Treewalker.move_out = ensuring_parser(movement.move_out)
 Treewalker.move_down = ensuring_parser(movement.move_down)
 Treewalker.move_in = ensuring_parser(movement.move_in)
 
+Treewalker.select_up = ensuring_parser(movement.select_up)
+Treewalker.select_out = ensuring_parser(movement.select_out)
+Treewalker.select_down = ensuring_parser(movement.select_down)
+Treewalker.select_in = ensuring_parser(movement.select_in)
+
 Treewalker.swap_up = ensuring_parser(swap.swap_up)
 Treewalker.swap_down = ensuring_parser(swap.swap_down)
 Treewalker.swap_right = ensuring_parser(swap.swap_right)

--- a/lua/treewalker/movement.lua
+++ b/lua/treewalker/movement.lua
@@ -5,7 +5,7 @@ local nodes = require "treewalker.nodes"
 local M = {}
 
 ---@return nil
-function M.move_out()
+local function move_out(select)
   vim.cmd("normal! ^") -- TODO can somehow use nodes.get_at_row for this instead of this junk?
   local node = nodes.get_current()
   local target, row = targets.out(node)
@@ -15,21 +15,21 @@ function M.move_out()
     return
   end
   vim.cmd("normal! m'") -- Add originating node to jump list
-  operations.jump(target, row)
+  operations.jump(target, row, select)
   vim.cmd("normal! m'") -- Add destination node to jump list
 end
 
 ---@return nil
-function M.move_in()
+local function move_in(select)
   local target, row = targets.inn()
   if not target or not row then return end
   vim.cmd("normal! m'")
-  operations.jump(target, row)
+  operations.jump(target, row, select)
   vim.cmd("normal! m'")
 end
 
 ---@return nil
-function M.move_up()
+local function move_up(select)
   local node = nodes.get_current()
   local target, row = targets.up()
   if not target or not row then return end
@@ -40,11 +40,11 @@ function M.move_up()
     vim.cmd("normal! m'")
   end
 
-  operations.jump(target, row)
+  operations.jump(target, row, select)
 end
 
 ---@return nil
-function M.move_down()
+local function move_down(select)
   local node = nodes.get_current()
   local target, row = targets.down()
   if not target or not row then return end
@@ -55,11 +55,43 @@ function M.move_down()
     vim.cmd("normal! m'")
   end
 
-  operations.jump(target, row)
+  operations.jump(target, row, select)
 
   if not is_neighbor then
     vim.cmd("normal! m'")
   end
+end
+
+function M.move_out()
+  move_out(false)
+end
+
+function M.move_in()
+  move_in(false)
+end
+
+function M.move_up()
+  move_up(false)
+end
+
+function M.move_down()
+  move_down(false)
+end
+
+function M.select_out()
+  move_out(true)
+end
+
+function M.select_in()
+  move_in(true)
+end
+
+function M.select_up()
+  move_up(true)
+end
+
+function M.select_down()
+  move_down(true)
 end
 
 return M

--- a/lua/treewalker/operations.lua
+++ b/lua/treewalker/operations.lua
@@ -28,14 +28,26 @@ end
 
 ---@param node TSNode
 ---@param row integer
-function M.jump(node, row)
+function M.jump(node, row, select)
   vim.api.nvim_win_set_cursor(0, { row, 0 })
   vim.cmd("normal! ^")  -- Jump to start of line
-  if require("treewalker").opts.highlight then
+  if select then
     local range = nodes.range(node)
-    local duration = require("treewalker").opts.highlight_duration
-    local hl_group = require("treewalker").opts.highlight_group
-    M.highlight(range, duration, hl_group)
+    local mode = vim.api.nvim_get_mode().mode
+    if mode ~= "n" then
+      local esc = vim.api.nvim_replace_termcodes('<esc>', true, false, true)
+      vim.api.nvim_feedkeys(esc, 'x', false)
+    end
+    vim.cmd("normal! v")
+    vim.api.nvim_win_set_cursor(0, { range[3] + 1, range[4] })
+    vim.cmd("normal! o")
+  else
+    if require("treewalker").opts.highlight then
+      local range = nodes.range(node)
+      local duration = require("treewalker").opts.highlight_duration
+      local hl_group = require("treewalker").opts.highlight_group
+      M.highlight(range, duration, hl_group)
+    end
   end
 end
 

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -25,6 +25,21 @@ local subcommands = {
   Right = function()
     tw().move_in()
   end,
+  SelectUp = function()
+    tw().select_up()
+  end,
+
+  SelectLeft = function()
+    tw().select_out()
+  end,
+
+  SelectDown = function()
+    tw().select_down()
+  end,
+
+  SelectRight = function()
+    tw().select_in()
+  end,
 
   SwapUp = function()
     tw().swap_up()


### PR DESCRIPTION
Thank you for the plugin, it is more intuitive than others I have been using. I was missing one little thing, which was automatic selection of the nodes while navigating. This lets me operate on the node without having to use a visual text object. This PR adds that functionality.

Feel free to use or ignore if you think it is not something you want included.

If you decide to test this PR, you will see it unfolds a bug in the plugin. The bug is irrelevant when using the plugin for movement alone, but it is clear when you use these new selection modes. The treesitter node when moving `inn` (`strategies.get_down_and_in())` is different (smaller) than if you move `down` and then `up` again from it. It is not important, but maybe you want to have a look at it. I am not very familiar with the code yet.

Again, thank you.