### PR TITLE
Added formatting requirements using with StyLua

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,10 +30,18 @@ jobs:
         git clone https://github.com/nvim-treesitter/nvim-treesitter.git
         mv nvim-treesitter $HOME/.local/share/nvim/lazy/
 
+    - name: Install Stylua
+      run: |
+        sudo apt-get install npm -y --no-install-recommends
+        sudo npm install -g @johnnymorganz/stylua-bin
+
     - name: Run luacheck type check / linter
       run: |
         sudo apt-get install lua-check -y --no-install-recommends
         make check
+
+    - name: Check formatting
+      run: make check-fmt
 
     - name: Check for errant util calls
       run: make no-utils

--- a/.styluaignore
+++ b/.styluaignore
@@ -1,0 +1,1 @@
+tests/fixtures/*.lua

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MINIMAL_INIT=tests/minimal_init.lua
 TESTS_DIR=tests
 NO_UTIL_SPEC=checks
 
-.PHONY: test test-watch check no-utils pass help
+.PHONY: test test-watch check no-utils pass help fmt check-fmt
 
 test: ## Run the whole test suite
 	@nvim \
@@ -24,7 +24,13 @@ no-utils: ## Make sure there are no errant util calls which write to data direct
 		-u ${MINIMAL_INIT} \
 		-c "PlenaryBustedDirectory ${NO_UTIL_SPEC} { minimal_init = '${MINIMAL_INIT}' }"
 
-pass: test no-utils check ## Run everything, if it's a 0 code, everything's good
+pass: test no-utils check check-fmt ## Run everything, if it's a 0 code, everything's good
+	
+fmt: ## Run stylua on the project (lua code style linter), including automatic changes
+	stylua ./
+
+check-fmt: ## Check stylua on the project, only emitting errors, not modifying project at all
+	stylua --check ./
 
 help: ## Displays this information.
 	@printf '%s\n' "Usage: make <command>"

--- a/checks/rogue_util_calls_spec.lua
+++ b/checks/rogue_util_calls_spec.lua
@@ -2,10 +2,10 @@
 -- util functions like R and log. This isn't perfect, as it tries to exercise
 -- each command, but doesn't seek edge cases.
 
-local load_fixture = require "tests.load_fixture"
-local assert = require 'luassert'
-local stub = require 'luassert.stub'
-local util = require 'treewalker.util'
+local load_fixture = require("tests.load_fixture")
+local assert = require("luassert")
+local stub = require("luassert.stub")
+local util = require("treewalker.util")
 
 local commands = {
   "Treewalker Up",
@@ -39,7 +39,7 @@ describe("Extent util calls:", function()
 
   before_each(function()
     load_fixture("/lua.lua")
-    vim.opt.fileencoding = 'utf-8'
+    vim.opt.fileencoding = "utf-8"
     vim.fn.cursor(31, 26)
   end)
 

--- a/lua/treewalker/augment.lua
+++ b/lua/treewalker/augment.lua
@@ -1,4 +1,4 @@
-local nodes = require "treewalker.nodes"
+local nodes = require("treewalker.nodes")
 
 local M = {}
 

--- a/lua/treewalker/init.lua
+++ b/lua/treewalker/init.lua
@@ -1,6 +1,6 @@
-local movement = require('treewalker.movement')
-local swap = require('treewalker.swap')
-local options = require('treewalker.options')
+local movement = require("treewalker.movement")
+local swap = require("treewalker.swap")
+local options = require("treewalker.options")
 
 local Treewalker = {}
 
@@ -15,14 +15,16 @@ Treewalker.opts = {
 -- This does not need to be called for Treewalker to work. The defaults are preinitialized and aim to be sane.
 ---@param opts Opts | nil
 function Treewalker.setup(opts)
-  if opts == nil then return end -- nil is valid, in which case we stick to the defaults
+  if opts == nil then
+    return
+  end -- nil is valid, in which case we stick to the defaults
 
   local is_opts_valid, validation_errors = options.validate_opts(opts)
   if not is_opts_valid then
     return options.handle_opts_validation_errors(validation_errors)
   end
 
-  Treewalker.opts = vim.tbl_deep_extend('force', Treewalker.opts, opts)
+  Treewalker.opts = vim.tbl_deep_extend("force", Treewalker.opts, opts)
 end
 
 -- Makes sure the treesitter parser is available, otherwise makes a notification

--- a/lua/treewalker/movement.lua
+++ b/lua/treewalker/movement.lua
@@ -1,6 +1,6 @@
-local operations = require "treewalker.operations"
-local targets = require "treewalker.targets"
-local nodes = require "treewalker.nodes"
+local operations = require("treewalker.operations")
+local targets = require("treewalker.targets")
+local nodes = require("treewalker.nodes")
 
 local M = {}
 
@@ -22,7 +22,9 @@ end
 ---@return nil
 function M.move_in()
   local target, row = targets.inn()
-  if not target or not row then return end
+  if not target or not row then
+    return
+  end
   vim.cmd("normal! m'")
   operations.jump(target, row)
   vim.cmd("normal! m'")
@@ -32,7 +34,9 @@ end
 function M.move_up()
   local node = nodes.get_current()
   local target, row = targets.up()
-  if not target or not row then return end
+  if not target or not row then
+    return
+  end
 
   -- No neighbor jumplist additions in up
   local is_neighbor = nodes.have_neighbor_srow(node, target)
@@ -47,7 +51,9 @@ end
 function M.move_down()
   local node = nodes.get_current()
   local target, row = targets.down()
-  if not target or not row then return end
+  if not target or not row then
+    return
+  end
 
   -- down needs neighbor before and after jump
   local is_neighbor = nodes.have_neighbor_srow(node, target)

--- a/lua/treewalker/nodes.lua
+++ b/lua/treewalker/nodes.lua
@@ -1,17 +1,17 @@
-local lines = require "treewalker.lines"
-local util = require "treewalker.util"
+local lines = require("treewalker.lines")
+local util = require("treewalker.util")
 
 -- These are regexes but just happen to be real simple so far
 local TARGET_BLACKLIST_TYPE_MATCHERS = {
   "comment",
-  "source",             -- On Ubuntu, on nvim 0.11, TS is diff for comments, with source as the child of comment
-  "attribute_item",     -- decorators (rust)
-  "decorat",            -- decorators (py)
-  "else",               -- else/elseif statements (lua)
-  "elif",               -- else/elseif statements (py)
-  "end_tag",            -- html closing tags
-  "block",              -- C# puts their blocks under their fn names like a psycho
-  "declaration_list",   -- C# class blocks
+  "source", -- On Ubuntu, on nvim 0.11, TS is diff for comments, with source as the child of comment
+  "attribute_item", -- decorators (rust)
+  "decorat", -- decorators (py)
+  "else", -- else/elseif statements (lua)
+  "elif", -- else/elseif statements (py)
+  "end_tag", -- html closing tags
+  "block", -- C# puts their blocks under their fn names like a psycho
+  "declaration_list", -- C# class blocks
   "compound_statement", -- C blocks when defined under their fn names like a psycho
 }
 
@@ -22,9 +22,9 @@ local HIGHLIGHT_BLACKLIST_TYPE_MATCHERS = {
 
 local AUGMENT_TARGET_TYPE_MATCHERS = {
   "comment",
-  "source",         -- On Ubuntu, on nvim 0.11, TS is diff for comments, with source as the child of comment
+  "source", -- On Ubuntu, on nvim 0.11, TS is diff for comments, with source as the child of comment
   "attribute_item", -- decorators (rust)
-  "decorat",        -- decorators (py)
+  "decorat", -- decorators (py)
 }
 
 local M = {}
@@ -44,35 +44,23 @@ end
 ---@param node TSNode
 ---@return boolean
 local function is_root_node(node)
-  return
-      true
-      and node:parent() == nil
-      and node:range() == 0
+  return true and node:parent() == nil and node:range() == 0
 end
 
 ---@param node TSNode
 ---@return boolean
 function M.is_jump_target(node)
-  return
-      true
-      and not is_matched_in(node, TARGET_BLACKLIST_TYPE_MATCHERS)
-      and not is_root_node(node)
+  return true and not is_matched_in(node, TARGET_BLACKLIST_TYPE_MATCHERS) and not is_root_node(node)
 end
 
 ---@param node TSNode
 ---@return boolean
 function M.is_highlight_target(node)
-  return
-      true
-      and not is_matched_in(node, HIGHLIGHT_BLACKLIST_TYPE_MATCHERS)
-      and not is_root_node(node)
+  return true and not is_matched_in(node, HIGHLIGHT_BLACKLIST_TYPE_MATCHERS) and not is_root_node(node)
 end
 
 function M.is_augment_target(node)
-  return
-      true
-      and is_matched_in(node, AUGMENT_TARGET_TYPE_MATCHERS)
-      and not is_root_node(node)
+  return true and is_matched_in(node, AUGMENT_TARGET_TYPE_MATCHERS) and not is_root_node(node)
 end
 
 ---Do the nodes have the same starting row
@@ -88,10 +76,7 @@ end
 ---@param node2 TSNode
 ---@return boolean
 function M.have_neighbor_srow(node1, node2)
-  return
-      false
-      or M.get_srow(node1) == M.get_srow(node2) + 1
-      or M.get_srow(node1) == M.get_srow(node2) - 1
+  return false or M.get_srow(node1) == M.get_srow(node2) + 1 or M.get_srow(node1) == M.get_srow(node2) - 1
 end
 
 ---Do the nodes have the same level of indentation
@@ -153,7 +138,9 @@ function M.get_from_neighboring_line(current_row, dir)
     candidate_row = current_row + 1
   end
   local max_row = vim.api.nvim_buf_line_count(0)
-  if candidate_row > max_row or candidate_row <= 0 then return end
+  if candidate_row > max_row or candidate_row <= 0 then
+    return
+  end
   local candidate = M.get_at_row(candidate_row)
   local candidate_line = lines.get_line(candidate_row)
 
@@ -172,14 +159,18 @@ end
 -- Convenience for give me back next sibling of a potentially nil node
 ---@param node TSNode | nil
 function M.next_sib(node)
-  if not node then return nil end
+  if not node then
+    return nil
+  end
   return node:next_named_sibling()
 end
 
 -- Convenience for give me back prev sibling of a potentially nil node
 ---@param node TSNode | nil
 function M.prev_sib(node)
-  if not node then return nil end
+  if not node then
+    return nil
+  end
   return node:prev_named_sibling()
 end
 
@@ -192,7 +183,9 @@ function M.get_highest_row_coincident(node)
   ---@type TSNode | nil
   local iter = node
   while iter and M.have_same_srow(node, iter) do
-    if M.is_highlight_target(iter) then node = iter end
+    if M.is_highlight_target(iter) then
+      node = iter
+    end
     iter = iter:parent()
   end
   return node
@@ -204,7 +197,9 @@ end
 function M.get_highest_coincident(node)
   local iter = node:parent()
   while iter and M.have_same_srow(node, iter) and M.have_same_scol(node, iter) do
-    if M.is_highlight_target(iter) then node = iter end
+    if M.is_highlight_target(iter) then
+      node = iter
+    end
     iter = iter:parent()
   end
   return node
@@ -227,8 +222,12 @@ function M.whole_range(nodes)
 
   for _, node in ipairs(nodes) do
     local srow, _, erow = node:range()
-    if srow < min_row then min_row = srow end
-    if erow > max_row then max_row = erow end
+    if srow < min_row then
+      min_row = srow
+    end
+    if erow > max_row then
+      max_row = erow
+    end
   end
 
   return { min_row, max_row }
@@ -242,7 +241,7 @@ function M.lsp_range(node)
   local start_line, start_col, end_line, end_col = node:range()
   return {
     start = { line = start_line, character = start_col },
-    ["end"] = { line = end_line, character = end_col }
+    ["end"] = { line = end_line, character = end_col },
   }
 end
 
@@ -300,7 +299,9 @@ end
 ---@return TSNode|nil
 function M.get_at_row(row)
   local line = lines.get_line(row)
-  if not line then return end
+  if not line then
+    return
+  end
   local col = lines.get_start_col(line)
   return vim.treesitter.get_node({
     pos = { row - 1, col - 1 },
@@ -336,7 +337,9 @@ end
 ---@param depth number | nil
 ---@return nil
 function M.log_parents(node, depth)
-  if not depth then depth = 4 end
+  if not depth then
+    depth = 4
+  end
   ---@type TSNode | nil
   local current_node = node
   local log_string = node:type()
@@ -345,7 +348,9 @@ function M.log_parents(node, depth)
   -- Loop to traverse up to 3 parent nodes
   while current_node and current_depth <= depth do
     current_node = current_node:parent()
-    if not current_node then break end
+    if not current_node then
+      break
+    end
     log_string = current_node:type() .. "->" .. log_string
     current_depth = current_depth + 1
   end

--- a/lua/treewalker/operations.lua
+++ b/lua/treewalker/operations.lua
@@ -1,5 +1,5 @@
-local nodes = require 'treewalker.nodes'
-local lines = require 'treewalker.lines'
+local nodes = require("treewalker.nodes")
+local lines = require("treewalker.lines")
 
 local M = {}
 
@@ -30,7 +30,7 @@ end
 ---@param row integer
 function M.jump(node, row)
   vim.api.nvim_win_set_cursor(0, { row, 0 })
-  vim.cmd("normal! ^")  -- Jump to start of line
+  vim.cmd("normal! ^") -- Jump to start of line
   if require("treewalker").opts.highlight then
     local range = nodes.range(node)
     local duration = require("treewalker").opts.highlight_duration
@@ -74,11 +74,11 @@ function M.swap_nodes(left, right)
   local edit1 = { range = range1, newText = table.concat(text2, "\n") }
   local edit2 = { range = range2, newText = table.concat(text1, "\n") }
   local bufnr = vim.api.nvim_get_current_buf()
-  local encoding = vim.api.nvim_get_option_value('fileencoding', {})
-  if not encoding or encoding == "" then encoding = "utf-8" end -- #23
+  local encoding = vim.api.nvim_get_option_value("fileencoding", {})
+  if not encoding or encoding == "" then
+    encoding = "utf-8"
+  end -- #23
   vim.lsp.util.apply_text_edits({ edit1, edit2 }, bufnr, encoding)
 end
 
 return M
-
-

--- a/lua/treewalker/options.lua
+++ b/lua/treewalker/options.lua
@@ -14,8 +14,10 @@ function M.validate_opts(opts)
     table.insert(errors, "`highlight_duration` should be an integer or nil")
   end
   if type(opts.highlight_group) ~= "string" and opts.highlight_group ~= nil then
-    table.insert(errors,
-      "`highlight_group` should be a valid vim highlight-group or nil. See :h highlight-group for available options.")
+    table.insert(
+      errors,
+      "`highlight_group` should be a valid vim highlight-group or nil. See :h highlight-group for available options."
+    )
   end
 
   if #errors == 0 then

--- a/lua/treewalker/strategies.lua
+++ b/lua/treewalker/strategies.lua
@@ -33,8 +33,8 @@
 -- a single node won't use this technique, as the following works better, preserving all types:
 -- node = strategies.whatever(node) or node
 
-local lines = require('treewalker.lines')
-local nodes = require('treewalker.nodes')
+local lines = require("treewalker.lines")
+local nodes = require("treewalker.nodes")
 
 local M = {}
 
@@ -52,12 +52,12 @@ function M.get_neighbor_at_same_col(dir, srow, scol, prev_candidate, prev_row)
     local candidate_col = lines.get_start_col(candidate_line)
     local strow = candidate:range()
     if
-        nodes.is_jump_target(candidate)   -- only node types we consider jump targets
-        and candidate_line ~= ""          -- no empty lines
-        and candidate_col == scol         -- stay at current indent level
-        and candidate_row == strow + 1    -- top of block; no end's or else's etc.
+      nodes.is_jump_target(candidate) -- only node types we consider jump targets
+      and candidate_line ~= "" -- no empty lines
+      and candidate_col == scol -- stay at current indent level
+      and candidate_row == strow + 1 -- top of block; no end's or else's etc.
     then
-      break                               -- use most recent assignment below
+      break -- use most recent assignment below
     else
       candidate, candidate_row, candidate_line = nodes.get_from_neighboring_line(candidate_row, dir)
     end
@@ -80,11 +80,15 @@ function M.get_down_and_in(srow, scol, prev_candidate, prev_row)
   local last_row = vim.api.nvim_buf_line_count(0)
 
   -- Can't go down if we're at the bottom
-  if last_row == srow then return prev_candidate, prev_row end
+  if last_row == srow then
+    return prev_candidate, prev_row
+  end
 
   for candidate_row = srow + 1, last_row, 1 do
     local candidate_line = lines.get_line(candidate_row)
-    if not candidate_line then goto continue end
+    if not candidate_line then
+      goto continue
+    end
     local candidate_col = lines.get_start_col(candidate_line)
     local candidate = nodes.get_at_row(candidate_row)
     local is_empty = candidate_line == ""
@@ -111,7 +115,9 @@ end
 ---@return TSNode | nil, integer | nil
 function M.get_next_if_on_empty_line(srow, prev_candidate, prev_row)
   local start_line = lines.get_line(srow)
-  if start_line ~= "" then return prev_candidate, prev_row end
+  if start_line ~= "" then
+    return prev_candidate, prev_row
+  end
 
   ---@type string | nil
   local current_line = start_line
@@ -120,17 +126,17 @@ function M.get_next_if_on_empty_line(srow, prev_candidate, prev_row)
   local current_node = nodes.get_at_row(current_row)
 
   while
-    true
-    and current_line == ""
-    or current_node and not nodes.is_jump_target(current_node)
-    and current_row <= max_row
+    true and current_line == ""
+    or current_node and not nodes.is_jump_target(current_node) and current_row <= max_row
   do
     current_row = current_row + 1
     current_line = lines.get_line(current_row)
     current_node = nodes.get_at_row(current_row)
   end
 
-  if current_row > max_row then return prev_candidate, prev_row end
+  if current_row > max_row then
+    return prev_candidate, prev_row
+  end
 
   if current_node and current_row then
     return current_node, current_row
@@ -147,25 +153,24 @@ end
 ---@return TSNode | nil, integer | nil
 function M.get_prev_if_on_empty_line(srow, prev_candidate, prev_row)
   local start_line = lines.get_line(srow)
-  if start_line ~= "" then return prev_candidate, prev_row end
+  if start_line ~= "" then
+    return prev_candidate, prev_row
+  end
 
   ---@type string | nil
   local current_line = start_line
   local current_row = srow
   local current_node = nodes.get_at_row(current_row)
 
-  while
-    true
-    and current_line == ""
-    or current_node and not nodes.is_jump_target(current_node)
-    and current_row >= 0
-  do
+  while true and current_line == "" or current_node and not nodes.is_jump_target(current_node) and current_row >= 0 do
     current_row = current_row - 1
     current_line = lines.get_line(current_row)
     current_node = nodes.get_at_row(current_row)
   end
 
-  if current_row < 0 then return prev_candidate, prev_row end
+  if current_row < 0 then
+    return prev_candidate, prev_row
+  end
 
   if current_node and current_row then
     return current_node, current_row
@@ -180,11 +185,7 @@ end
 function M.get_first_ancestor_with_diff_scol(node)
   local iter_ancestor = node:parent()
   while iter_ancestor do
-    if
-        true
-        and nodes.is_jump_target(iter_ancestor)
-        and not nodes.have_same_scol(node, iter_ancestor)
-    then
+    if true and nodes.is_jump_target(iter_ancestor) and not nodes.have_same_scol(node, iter_ancestor) then
       return iter_ancestor
     end
 

--- a/lua/treewalker/swap.lua
+++ b/lua/treewalker/swap.lua
@@ -1,17 +1,23 @@
-local nodes = require "treewalker.nodes"
-local operations = require "treewalker.operations"
-local targets = require "treewalker.targets"
-local augment = require "treewalker.augment"
-local strategies = require "treewalker.strategies"
+local nodes = require("treewalker.nodes")
+local operations = require("treewalker.operations")
+local targets = require("treewalker.targets")
+local augment = require("treewalker.augment")
+local strategies = require("treewalker.strategies")
 
 local M = {}
 
 ---@return boolean
 local function is_on_target_node()
   local node = vim.treesitter.get_node()
-  if not node then return false end
-  if not nodes.is_jump_target(node) then return false end
-  if vim.fn.line('.') - 1 ~= node:range() then return false end
+  if not node then
+    return false
+  end
+  if not nodes.is_jump_target(node) then
+    return false
+  end
+  if vim.fn.line(".") - 1 ~= node:range() then
+    return false
+  end
   return true
 end
 
@@ -33,13 +39,19 @@ end
 
 function M.swap_down()
   vim.cmd("normal! ^")
-  if not is_on_target_node() then return end
-  if not is_supported_ft() then return end
+  if not is_on_target_node() then
+    return
+  end
+  if not is_supported_ft() then
+    return
+  end
 
   local current = nodes.get_current()
 
   local target = targets.down()
-  if not target then return end
+  if not target then
+    return
+  end
 
   current = nodes.get_highest_coincident(current)
 
@@ -69,12 +81,18 @@ end
 
 function M.swap_up()
   vim.cmd("normal! ^")
-  if not is_on_target_node() then return end
-  if not is_supported_ft() then return end
+  if not is_on_target_node() then
+    return
+  end
+  if not is_supported_ft() then
+    return
+  end
 
   local current = nodes.get_current()
   local target = targets.up()
-  if not target then return end
+  if not target then
+    return
+  end
 
   current = nodes.get_highest_coincident(current)
 
@@ -107,7 +125,9 @@ function M.swap_up()
 end
 
 function M.swap_right()
-  if not is_supported_ft() then return end
+  if not is_supported_ft() then
+    return
+  end
 
   -- Iteratively more desirable
   local current = nodes.get_current()
@@ -116,7 +136,9 @@ function M.swap_right()
 
   local target = nodes.next_sib(current)
 
-  if not current or not target then return end
+  if not current or not target then
+    return
+  end
 
   -- set a mark to track where the target started, so we may later go there after the swap
   local ns_id = vim.api.nvim_create_namespace("treewalker#swap_right")
@@ -127,19 +149,20 @@ function M.swap_right()
   local ext = vim.api.nvim_buf_get_extmark_by_id(0, ns_id, ext_id, {})
   local new_current = nodes.get_at_rowcol(ext[1] + 1, ext[2] - 1)
 
-  if not new_current then return end
+  if not new_current then
+    return
+  end
 
-  vim.fn.cursor(
-    nodes.get_srow(new_current),
-    nodes.get_scol(new_current)
-  )
+  vim.fn.cursor(nodes.get_srow(new_current), nodes.get_scol(new_current))
 
   -- cleanup
   vim.api.nvim_buf_clear_namespace(0, ns_id, 0, -1)
 end
 
 function M.swap_left()
-  if not is_supported_ft() then return end
+  if not is_supported_ft() then
+    return
+  end
 
   -- Iteratively more desirable
   local current = nodes.get_current()
@@ -148,15 +171,14 @@ function M.swap_left()
 
   local target = nodes.prev_sib(current)
 
-  if not current or not target then return end
+  if not current or not target then
+    return
+  end
 
   operations.swap_nodes(target, current)
 
   -- Place cursor
-  vim.fn.cursor(
-    nodes.get_srow(target),
-    nodes.get_scol(target)
-  )
+  vim.fn.cursor(nodes.get_srow(target), nodes.get_scol(target))
 end
 
 return M

--- a/lua/treewalker/targets.lua
+++ b/lua/treewalker/targets.lua
@@ -1,6 +1,6 @@
-local lines = require "treewalker.lines"
-local nodes = require "treewalker.nodes"
-local strategies = require "treewalker.strategies"
+local lines = require("treewalker.lines")
+local nodes = require("treewalker.nodes")
+local strategies = require("treewalker.strategies")
 
 local M = {}
 
@@ -33,7 +33,9 @@ end
 function M.out(node)
   local candidate = strategies.get_first_ancestor_with_diff_scol(node)
   candidate = coincident(candidate)
-  if not candidate then return end
+  if not candidate then
+    return
+  end
   local row = nodes.get_srow(candidate)
   return candidate, row
 end

--- a/lua/treewalker/util.lua
+++ b/lua/treewalker/util.lua
@@ -40,7 +40,9 @@ M.log = function(...)
   -- Swallow further errors
   -- This is a utility for development, it should never cause issues
   -- during real use.
-  if not log_file then return end
+  if not log_file then
+    return
+  end
 
   -- Write each arg to disk
   for _, arg in ipairs(args) do
@@ -56,16 +58,16 @@ M.log = function(...)
 end
 
 M.guid = function()
-  local template = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'
-  return string.gsub(template, '[xy]', function(c)
-    local v = (c == 'x') and math.random(0, 0xf) or math.random(8, 0xb)
-    return string.format('%x', v)
+  local template = "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx"
+  return string.gsub(template, "[xy]", function(c)
+    local v = (c == "x") and math.random(0, 0xf) or math.random(8, 0xb)
+    return string.format("%x", v)
   end)
 end
 
 ---reverse an array table
 ---@param t table
-M.reverse = function (t)
+M.reverse = function(t)
   local reversed = {}
   for _, el in ipairs(t) do
     table.insert(reversed, 1, el)

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -3,13 +3,13 @@ local function tw()
     -- For development. Makes the plugin auto-reload so you
     -- don't need to restart nvim to get the changes live.
     -- F*** it, we're doing it live!
-    local util = require "treewalker.util"
-    local initial_opts = require('treewalker').opts
-    local treewalker = util.R('treewalker')
+    local util = require("treewalker.util")
+    local initial_opts = require("treewalker").opts
+    local treewalker = util.R("treewalker")
     treewalker.setup(initial_opts)
     return treewalker
   else
-    return require('treewalker')
+    return require("treewalker")
   end
 end
 
@@ -44,7 +44,7 @@ local subcommands = {
 
   SwapRight = function()
     tw().swap_right()
-  end
+  end,
 }
 
 local command_opts = {
@@ -53,7 +53,7 @@ local command_opts = {
     return vim.tbl_filter(function(cmd)
       return cmd:match("^" .. ArgLead)
     end, vim.tbl_keys(subcommands))
-  end
+  end,
 }
 
 local function treewalker(opts)

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,2 @@
+indent_type = "Spaces"
+indent_width = 2

--- a/tests/load_fixture.lua
+++ b/tests/load_fixture.lua
@@ -1,4 +1,4 @@
-local fixtures_dir = vim.fn.expand 'tests/fixtures'
+local fixtures_dir = vim.fn.expand("tests/fixtures")
 
 ---@param filename string
 ---@return string

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -9,32 +9,32 @@ vim.opt.swapfile = false
 vim.cmd("runtime! plugin/treewalker.nvim")
 vim.cmd("runtime! plugin/plenary.vim")
 vim.cmd("runtime! plugin/nvim-treesitter")
-require('nvim-treesitter.configs').setup {
-    ensure_installed = {
-        "lua",
-        "c",
-        "python",
-        "rust",
-        "haskell",
-        "html",
-        "javascript",
-        "c_sharp",
-        "typescript",
-        "php",
-        "markdown",
-        "ruby",
-        "scheme",
-    },
-    sync_install = true,
-    auto_install = true,
-    ignore_install = {},
-    modules = {}
-}
+require("nvim-treesitter.configs").setup({
+  ensure_installed = {
+    "lua",
+    "c",
+    "python",
+    "rust",
+    "haskell",
+    "html",
+    "javascript",
+    "c_sharp",
+    "typescript",
+    "php",
+    "markdown",
+    "ruby",
+    "scheme",
+  },
+  sync_install = true,
+  auto_install = true,
+  ignore_install = {},
+  modules = {},
+})
 
 -- These are required lest nvim not be able to tell these parsers are installed
-vim.treesitter.language.register('ruby', { 'rb' })
-vim.treesitter.language.register('markdown', { 'md' })
-vim.treesitter.language.register('javascript', { 'js' })
-vim.treesitter.language.register('scheme', { 'scm' })
+vim.treesitter.language.register("ruby", { "rb" })
+vim.treesitter.language.register("markdown", { "md" })
+vim.treesitter.language.register("javascript", { "js" })
+vim.treesitter.language.register("scheme", { "scm" })
 
 dofile("plugin/init.lua") -- get the Treewalker command present

--- a/tests/treewalker/c_sharp_spec.lua
+++ b/tests/treewalker/c_sharp_spec.lua
@@ -1,7 +1,7 @@
-local load_fixture = require "tests.load_fixture"
-local tw = require 'treewalker'
-local h = require 'tests.treewalker.helpers'
-local lines = require 'treewalker.lines'
+local load_fixture = require("tests.load_fixture")
+local tw = require("treewalker")
+local h = require("tests.treewalker.helpers")
+local lines = require("treewalker.lines")
 
 describe("In a C Sharp file", function()
   before_each(function()

--- a/tests/treewalker/c_spec.lua
+++ b/tests/treewalker/c_spec.lua
@@ -1,8 +1,8 @@
-local load_fixture = require "tests.load_fixture"
-local assert = require "luassert"
-local tw = require 'treewalker'
-local h = require 'tests.treewalker.helpers'
-local lines = require 'treewalker.lines'
+local load_fixture = require("tests.load_fixture")
+local assert = require("luassert")
+local tw = require("treewalker")
+local h = require("tests.treewalker.helpers")
+local lines = require("treewalker.lines")
 
 describe("In a c file:", function()
   before_each(function()

--- a/tests/treewalker/haskell_spec.lua
+++ b/tests/treewalker/haskell_spec.lua
@@ -1,6 +1,6 @@
-local load_fixture = require "tests.load_fixture"
-local tw = require 'treewalker'
-local h = require 'tests.treewalker.helpers'
+local load_fixture = require("tests.load_fixture")
+local tw = require("treewalker")
+local h = require("tests.treewalker.helpers")
 
 describe("In a haskell file: ", function()
   before_each(function()
@@ -10,7 +10,7 @@ describe("In a haskell file: ", function()
   h.ensure_has_parser("haskell")
 
   -- Oh dang when did this break?
-  pending("moves around in a haskell file", function ()
+  pending("moves around in a haskell file", function()
     vim.fn.cursor(1, 1)
     tw.move_down()
     h.assert_cursor_at(2, 1)
@@ -28,5 +28,3 @@ describe("In a haskell file: ", function()
     h.assert_cursor_at(19, 1)
   end)
 end)
-
-

--- a/tests/treewalker/helpers.lua
+++ b/tests/treewalker/helpers.lua
@@ -1,14 +1,14 @@
-local assert = require('luassert')
-local lines  = require('treewalker.lines')
+local assert = require("luassert")
+local lines = require("treewalker.lines")
 
-local M      = {}
+local M = {}
 
 -- Assert the cursor is in the expected position
 ---@param expected_row integer
 ---@param expected_col integer
 ---@param expected_line string?
 function M.assert_cursor_at(expected_row, expected_col, expected_line)
-  local cursor_pos = vim.fn.getpos('.')
+  local cursor_pos = vim.fn.getpos(".")
   local actual_row, actual_col = cursor_pos[2], cursor_pos[3]
   local actual_line = lines.get_line(actual_row)
 
@@ -31,7 +31,12 @@ function M.assert_cursor_at(expected_row, expected_col, expected_line)
   -- Just in case the test fails
   local error_line = string.format(
     "expected to be at [%s/%s](%s) but was at [%s/%s](%s)",
-    expected_row, expected_col, expected_line, actual_row, actual_col, actual_line
+    expected_row,
+    expected_col,
+    expected_line,
+    actual_row,
+    actual_col,
+    actual_line
   )
 
   assert.same({ expected_row, expected_col }, { actual_row, actual_col }, error_line)
@@ -42,7 +47,7 @@ end
 ---@return nil
 M.feed_keys = function(keys)
   local termcodes = vim.api.nvim_replace_termcodes(keys, true, true, true)
-  vim.api.nvim_feedkeys(termcodes, 'mtx', false)
+  vim.api.nvim_feedkeys(termcodes, "mtx", false)
 end
 
 -- This is more for the test suite itself and ensuring that it's operating correctly.
@@ -64,6 +69,5 @@ M.ensure_has_parser = function(lang)
     end
   end)
 end
-
 
 return M

--- a/tests/treewalker/highlight_spec.lua
+++ b/tests/treewalker/highlight_spec.lua
@@ -1,20 +1,16 @@
-local load_fixture = require "tests.load_fixture"
-local stub = require 'luassert.stub'
-local assert = require "luassert"
-local tw = require 'treewalker'
-local h = require 'tests.treewalker.helpers'
-local operations = require 'treewalker.operations'
+local load_fixture = require("tests.load_fixture")
+local stub = require("luassert.stub")
+local assert = require("luassert")
+local tw = require("treewalker")
+local h = require("tests.treewalker.helpers")
+local operations = require("treewalker.operations")
 
 local highlight_stub = stub(operations, "highlight")
 
 -- use with rows as they're numbered in vim lines (1-indexed)
 local function assert_highlighted(srow, scol, erow, ecol, desc)
   assert(highlight_stub.calls[1], "highlight was not called at all")
-  assert.same(
-    { srow - 1, scol - 1, erow - 1, ecol },
-    highlight_stub.calls[1].refs[1],
-    "highlight wrong for: " .. desc
-  )
+  assert.same({ srow - 1, scol - 1, erow - 1, ecol }, highlight_stub.calls[1].refs[1], "highlight wrong for: " .. desc)
 end
 
 describe("Highlights in a lua spec file: ", function()
@@ -29,7 +25,6 @@ describe("Highlights in a lua spec file: ", function()
     tw.move_in()
     assert_highlighted(67, 5, 85, 8, "it block")
   end)
-
 end)
 
 describe("Highlights in a regular lua file: ", function()

--- a/tests/treewalker/html_spec.lua
+++ b/tests/treewalker/html_spec.lua
@@ -1,6 +1,6 @@
-local load_fixture = require "tests.load_fixture"
-local tw = require 'treewalker'
-local h = require 'tests.treewalker.helpers'
+local load_fixture = require("tests.load_fixture")
+local tw = require("treewalker")
+local h = require("tests.treewalker.helpers")
 
 describe("In an html file", function()
   before_each(function()
@@ -27,7 +27,8 @@ describe("In an html file", function()
     vim.fn.cursor(59, 13)
     tw.move_out()
     h.assert_cursor_at(58, 9)
-    tw.move_up() tw.move_up()
+    tw.move_up()
+    tw.move_up()
     h.assert_cursor_at(55, 9)
     tw.move_in()
     h.assert_cursor_at(59, 13)

--- a/tests/treewalker/jump_list_spec.lua
+++ b/tests/treewalker/jump_list_spec.lua
@@ -1,14 +1,13 @@
-local load_fixture = require "tests.load_fixture"
-local tw = require 'treewalker'
-local helpers = require 'tests.treewalker.helpers'
+local load_fixture = require("tests.load_fixture")
+local tw = require("treewalker")
+local helpers = require("tests.treewalker.helpers")
 
 describe("Adding to the jumplist", function()
-
   -- This and the following are meant to be an omni test, and came before the
   -- tests that follow. But those tests are also valuable, so they remain.
   it("move_down adds jumps to jumplist", function()
     load_fixture("/lua-spec.lua")
-    vim.cmd('windo clearjumps')
+    vim.cmd("windo clearjumps")
     vim.fn.cursor(108, 1)
 
     -- This step is a bummer.
@@ -29,31 +28,31 @@ describe("Adding to the jumplist", function()
     helpers.assert_cursor_at(129, 3, "|vim.lsp.util")
 
     -- Unwind jumplist
-    helpers.feed_keys('<C-o>')
+    helpers.feed_keys("<C-o>")
     helpers.assert_cursor_at(120, 3, "|it(two)")
 
-    helpers.feed_keys('<C-o>')
+    helpers.feed_keys("<C-o>")
     helpers.assert_cursor_at(117, 3, "|local edit1")
 
-    helpers.feed_keys('<C-o>')
+    helpers.feed_keys("<C-o>")
     helpers.assert_cursor_at(115, 3)
 
-    helpers.feed_keys('<C-o>')
+    helpers.feed_keys("<C-o>")
     helpers.assert_cursor_at(114, 3)
 
-    helpers.feed_keys('<C-o>')
+    helpers.feed_keys("<C-o>")
     helpers.assert_cursor_at(112, 3)
 
-    helpers.feed_keys('<C-o>')
+    helpers.feed_keys("<C-o>")
     helpers.assert_cursor_at(109, 3)
 
-    helpers.feed_keys('<C-o>')
+    helpers.feed_keys("<C-o>")
     helpers.assert_cursor_at(108, 1)
   end)
 
   it("move_up adds jumps to jumplist", function()
     load_fixture("/lua-spec.lua")
-    vim.cmd('windo clearjumps')
+    vim.cmd("windo clearjumps")
     vim.fn.cursor(122, 5) -- part way into it block
     tw.move_out()
 
@@ -65,66 +64,69 @@ describe("Adding to the jumplist", function()
     helpers.assert_cursor_at(109, 3, "|local range1")
 
     -- unwind jumplist
-    helpers.feed_keys('<C-o>')
+    helpers.feed_keys("<C-o>")
     helpers.assert_cursor_at(114, 3, "|local text1")
 
-    helpers.feed_keys('<C-o>')
+    helpers.feed_keys("<C-o>")
     helpers.assert_cursor_at(117, 3, "|local edit1")
 
-    helpers.feed_keys('<C-o>')
+    helpers.feed_keys("<C-o>")
     helpers.assert_cursor_at(120, 3, "|it")
 
-    helpers.feed_keys('<C-o>')
+    helpers.feed_keys("<C-o>")
     helpers.assert_cursor_at(122, 5, "|tree")
   end)
 
   it("move_in adds single line jumps to the jumplist", function()
     load_fixture("/lua.lua")
-    vim.cmd('windo clearjumps')
+    vim.cmd("windo clearjumps")
     vim.fn.cursor(21, 1)
     tw.move_in()
     helpers.assert_cursor_at(22, 3, "for _,")
-    helpers.feed_keys('<C-o>')
+    helpers.feed_keys("<C-o>")
     helpers.assert_cursor_at(21, 1, "local function is_jump_target")
   end)
 
   it("move_out adds single line jumps to the jumplist", function()
     load_fixture("/lua.lua")
-    vim.cmd('windo clearjumps')
+    vim.cmd("windo clearjumps")
     vim.fn.cursor(132, 3)
     tw.move_out()
     helpers.assert_cursor_at(128, 1)
-    helpers.feed_keys('<C-o>')
+    helpers.feed_keys("<C-o>")
     helpers.assert_cursor_at(132, 3)
   end)
 
   it("move_down doesn't add single line jumps to the jumplist", function()
     load_fixture("/lua.lua")
-    vim.cmd('windo clearjumps')
+    vim.cmd("windo clearjumps")
     vim.fn.cursor(128, 1)
     -- vim.fn.cursor(129, 3)
 
     tw.move_in()
-    tw.move_down() tw.move_down() tw.move_down() tw.move_down()
+    tw.move_down()
+    tw.move_down()
+    tw.move_down()
+    tw.move_down()
     helpers.assert_cursor_at(136, 3)
-    helpers.feed_keys('<C-o>')
+    helpers.feed_keys("<C-o>")
     helpers.assert_cursor_at(132, 3)
-    helpers.feed_keys('<C-o>')
+    helpers.feed_keys("<C-o>")
     helpers.assert_cursor_at(129, 3)
   end)
 
   it("move_up doesn't add single line jumps to the jumplist", function()
     load_fixture("/lua.lua")
-    vim.cmd('windo clearjumps')
+    vim.cmd("windo clearjumps")
     vim.fn.cursor(133, 5)
     tw.move_out()
-    tw.move_up() tw.move_up() tw.move_up()
+    tw.move_up()
+    tw.move_up()
+    tw.move_up()
     helpers.assert_cursor_at(129, 3)
-    helpers.feed_keys('<C-o>')
+    helpers.feed_keys("<C-o>")
     helpers.assert_cursor_at(132, 3)
-    helpers.feed_keys('<C-o>')
+    helpers.feed_keys("<C-o>")
     helpers.assert_cursor_at(133, 5)
   end)
-
 end)
-

--- a/tests/treewalker/lines_spec.lua
+++ b/tests/treewalker/lines_spec.lua
@@ -3,7 +3,7 @@ local assert = require("luassert")
 local load_fixture = require("tests.load_fixture")
 
 describe("lines", function()
-  before_each(function ()
+  before_each(function()
     load_fixture("lua.lua")
   end)
 
@@ -47,7 +47,7 @@ describe("lines", function()
 
   describe(".insert_lines", function()
     it("inserts lines without deleting any", function()
-      lines.insert_lines(1, {"hiya"})
+      lines.insert_lines(1, { "hiya" })
       assert.same({ "local util = require('treewalker.util')", "hiya", "", "local M = {}" }, lines.get_lines(1, 4))
     end)
 

--- a/tests/treewalker/lua_spec.lua
+++ b/tests/treewalker/lua_spec.lua
@@ -1,9 +1,9 @@
-local load_fixture = require "tests.load_fixture"
-local assert = require "luassert"
-local stub = require "luassert.stub"
-local tw = require 'treewalker'
-local lines = require 'treewalker.lines'
-local h = require 'tests.treewalker.helpers'
+local load_fixture = require("tests.load_fixture")
+local assert = require("luassert")
+local stub = require("luassert.stub")
+local tw = require("treewalker")
+local lines = require("treewalker.lines")
+local h = require("tests.treewalker.helpers")
 
 describe("Movement in a regular lua file: ", function()
   before_each(function()
@@ -69,7 +69,7 @@ describe("Movement in a regular lua file: ", function()
 
   -- aka doesn't error
   it("is chill when down is invoked from empty last line", function()
-    h.feed_keys('G')
+    h.feed_keys("G")
     tw.move_down()
   end)
 
@@ -92,11 +92,10 @@ describe("Movement in a regular lua file: ", function()
   end)
 end)
 
-
 describe("Swapping in a regular lua file:", function()
   before_each(function()
     load_fixture("/lua.lua")
-    vim.o.fileencoding = 'utf-8'
+    vim.o.fileencoding = "utf-8"
   end)
 
   it("swap down bails early if user is on empty top level line", function()
@@ -141,7 +140,7 @@ describe("Swapping in a regular lua file:", function()
     assert.same({
       "local M = {}",
       "",
-      "local util = require('treewalker.util')"
+      "local util = require('treewalker.util')",
     }, lines.get_lines(1, 3))
     h.assert_cursor_at(3, 1)
   end)
@@ -183,14 +182,14 @@ describe("Swapping in a regular lua file:", function()
       "---Strictly sibling, no fancy business",
       "---@param node TSNode",
       "---@return TSNode | nil",
-      "local function get_prev_sibling(node)"
+      "local function get_prev_sibling(node)",
     }, lines.get_lines(34, 37))
     assert.same({
       "---Do the nodes have the same starting point",
       "---@param node1 TSNode",
       "---@param node2 TSNode",
       "---@return boolean",
-      "local function have_same_range(node1, node2)"
+      "local function have_same_range(node1, node2)",
     }, lines.get_lines(49, 53))
     h.assert_cursor_at(53, 1)
   end)
@@ -202,14 +201,14 @@ describe("Swapping in a regular lua file:", function()
       "---Strictly sibling, no fancy business",
       "---@param node TSNode",
       "---@return TSNode | nil",
-      "local function get_prev_sibling(node)"
+      "local function get_prev_sibling(node)",
     }, lines.get_lines(34, 37))
     assert.same({
       "---Do the nodes have the same starting point",
       "---@param node1 TSNode",
       "---@param node2 TSNode",
       "---@return boolean",
-      "local function have_same_range(node1, node2)"
+      "local function have_same_range(node1, node2)",
     }, lines.get_lines(49, 53))
     h.assert_cursor_at(37, 1)
   end)
@@ -247,8 +246,7 @@ describe("Swapping in a regular lua file:", function()
   end)
 
   it("swaps right diff number of lines", function()
-    assert.same("if true then", lines.get_line(185)
-    )
+    assert.same("if true then", lines.get_line(185))
     assert.same("return M", lines.get_line(193))
     vim.fn.cursor(185, 1)
     tw.swap_right()
@@ -287,7 +285,7 @@ describe("Swapping in a regular lua file:", function()
     local apply_text_edits_stub = stub(vim.lsp.util, "apply_text_edits")
 
     -- Prep the file encoding
-    local expected_encoding = 'utf-16'
+    local expected_encoding = "utf-16"
     vim.o.fileencoding = expected_encoding
 
     tw.swap_right()
@@ -307,8 +305,8 @@ describe("Swapping in a regular lua file:", function()
     local apply_text_edits_stub = stub(vim.lsp.util, "apply_text_edits")
 
     -- Prep the file encoding
-    local expected_encoding = 'utf-8'
-    vim.o.fileencoding = ''
+    local expected_encoding = "utf-8"
+    vim.o.fileencoding = ""
 
     tw.swap_right()
 
@@ -341,4 +339,3 @@ describe("Swapping in a regular lua file:", function()
     assert.same("  print('one' .. 'two' .. 'three')", lines.get_line(188))
   end)
 end)
-

--- a/tests/treewalker/lua_spec_spec.lua
+++ b/tests/treewalker/lua_spec_spec.lua
@@ -1,8 +1,8 @@
-local load_fixture = require "tests.load_fixture"
-local assert = require "luassert"
-local tw = require 'treewalker'
-local lines = require 'treewalker.lines'
-local h = require 'tests.treewalker.helpers'
+local load_fixture = require("tests.load_fixture")
+local assert = require("luassert")
+local tw = require("treewalker")
+local lines = require("treewalker.lines")
+local h = require("tests.treewalker.helpers")
 
 describe("In a lua spec file: ", function()
   before_each(function()
@@ -23,15 +23,18 @@ describe("In a lua spec file: ", function()
   -- go to first load_buf
   local function go_to_load_buf()
     go_to_describe()
-    tw.move_in(); tw.move_in()
+    tw.move_in()
+    tw.move_in()
     h.assert_cursor_at(19, 5, "load_buf")
   end
 
   it("moves up and down at the same pace", function()
     go_to_load_buf()
-    tw.move_down(); tw.move_down()
+    tw.move_down()
+    tw.move_down()
     h.assert_cursor_at(41, 5, "it")
-    tw.move_up(); tw.move_up()
+    tw.move_up()
+    tw.move_up()
     h.assert_cursor_at(19, 5, "load_buf")
   end)
 
@@ -58,7 +61,7 @@ describe("In a lua spec file: ", function()
   it("follows right swaps across rows (like in these it args)", function()
     vim.fn.cursor(21, 13)
     tw.swap_right()
-    assert.same('    it(function()', lines.get_line(21))
+    assert.same("    it(function()", lines.get_line(21))
     assert.same('    end, "moves up and down at the same pace")', lines.get_line(39))
     h.assert_cursor_at(39, 10)
   end)
@@ -67,7 +70,7 @@ describe("In a lua spec file: ", function()
     vim.fn.cursor(50, 13) -- go|es
     tw.swap_left()
     assert.same('    it("goes into functions eagerly", function()', lines.get_line(41))
-    assert.same('    end)', lines.get_line(50))
+    assert.same("    end)", lines.get_line(50))
     h.assert_cursor_at(41, 8)
   end)
 
@@ -90,6 +93,4 @@ describe("In a lua spec file: ", function()
     assert.same('    it("one", function()', lines.get_line(77))
     h.assert_cursor_at(67, 5)
   end)
-
 end)
-

--- a/tests/treewalker/markdown_spec.lua
+++ b/tests/treewalker/markdown_spec.lua
@@ -1,8 +1,8 @@
-local load_fixture = require "tests.load_fixture"
-local assert = require "luassert"
-local tw = require 'treewalker'
-local lines = require 'treewalker.lines'
-local h = require 'tests.treewalker.helpers'
+local load_fixture = require("tests.load_fixture")
+local assert = require("luassert")
+local tw = require("treewalker")
+local lines = require("treewalker.lines")
+local h = require("tests.treewalker.helpers")
 
 describe("Movement in a markdown file", function()
   before_each(function()

--- a/tests/treewalker/missing_parser_spec.lua
+++ b/tests/treewalker/missing_parser_spec.lua
@@ -1,7 +1,7 @@
-local load_fixture = require "tests.load_fixture"
-local assert = require 'luassert'
-local stub = require 'luassert.stub'
-local tw = require 'treewalker'
+local load_fixture = require("tests.load_fixture")
+local assert = require("luassert")
+local stub = require("luassert.stub")
+local tw = require("treewalker")
 
 local commands = {
   move_up = tw.move_up,
@@ -17,7 +17,7 @@ local commands = {
 describe("For a file in which there is a missing parser", function()
   before_each(function()
     load_fixture("/random.not_real", true)
-    vim.opt.fileencoding = 'utf-8'
+    vim.opt.fileencoding = "utf-8"
   end)
 
   for nam, command in pairs(commands) do

--- a/tests/treewalker/options_spec.lua
+++ b/tests/treewalker/options_spec.lua
@@ -1,6 +1,6 @@
-local assert = require 'luassert'
-local stub = require 'luassert.stub'
-local tw = require 'treewalker'
+local assert = require("luassert")
+local stub = require("luassert.stub")
+local tw = require("treewalker")
 
 describe("When given bad options", function()
   it("notifies the user of all wrong options", function()

--- a/tests/treewalker/php_spec.lua
+++ b/tests/treewalker/php_spec.lua
@@ -1,6 +1,6 @@
-local load_fixture = require "tests.load_fixture"
-local tw = require 'treewalker'
-local h = require 'tests.treewalker.helpers'
+local load_fixture = require("tests.load_fixture")
+local tw = require("treewalker")
+local h = require("tests.treewalker.helpers")
 
 describe("In a php file", function()
   before_each(function()
@@ -16,6 +16,4 @@ describe("In a php file", function()
     tw.move_down()
     h.assert_cursor_at(19, 1)
   end)
-
 end)
-

--- a/tests/treewalker/python_spec.lua
+++ b/tests/treewalker/python_spec.lua
@@ -1,8 +1,8 @@
-local load_fixture = require "tests.load_fixture"
-local assert = require "luassert"
-local tw = require 'treewalker'
-local lines = require 'treewalker.lines'
-local h = require 'tests.treewalker.helpers'
+local load_fixture = require("tests.load_fixture")
+local assert = require("luassert")
+local tw = require("treewalker")
+local lines = require("treewalker.lines")
+local h = require("tests.treewalker.helpers")
 
 describe("In a python file: ", function()
   before_each(function()
@@ -77,4 +77,3 @@ describe("In a python file: ", function()
     assert.same(top_before, lines.get_lines(135, 136))
   end)
 end)
-

--- a/tests/treewalker/ruby_spec.lua
+++ b/tests/treewalker/ruby_spec.lua
@@ -1,7 +1,7 @@
-local load_fixture = require "tests.load_fixture"
-local tw = require 'treewalker'
-local h = require 'tests.treewalker.helpers'
-local lines = require 'treewalker.lines'
+local load_fixture = require("tests.load_fixture")
+local tw = require("treewalker")
+local h = require("tests.treewalker.helpers")
+local lines = require("treewalker.lines")
 
 describe("In a ruby file: ", function()
   before_each(function()
@@ -40,4 +40,3 @@ describe("In a ruby file: ", function()
     h.assert_cursor_at(16, 3)
   end)
 end)
-

--- a/tests/treewalker/rust_spec.lua
+++ b/tests/treewalker/rust_spec.lua
@@ -1,8 +1,8 @@
-local load_fixture = require "tests.load_fixture"
-local assert = require "luassert"
-local tw = require 'treewalker'
-local lines = require 'treewalker.lines'
-local h = require 'tests.treewalker.helpers'
+local load_fixture = require("tests.load_fixture")
+local assert = require("luassert")
+local tw = require("treewalker")
+local lines = require("treewalker.lines")
+local h = require("tests.treewalker.helpers")
 
 describe("In a rust file:", function()
   before_each(function()
@@ -13,17 +13,17 @@ describe("In a rust file:", function()
 
   it("Swaps enum values right", function()
     vim.fn.cursor(49, 14)
-    assert.same('enum Color { Red, Green, Blue }', lines.get_line(49))
+    assert.same("enum Color { Red, Green, Blue }", lines.get_line(49))
     tw.swap_right()
-    assert.same('enum Color { Green, Red, Blue }', lines.get_line(49))
+    assert.same("enum Color { Green, Red, Blue }", lines.get_line(49))
     h.assert_cursor_at(49, 21, "Red")
   end)
 
   it("Swaps enum values left", function()
     vim.fn.cursor(49, 19)
-    assert.same('enum Color { Red, Green, Blue }', lines.get_line(49))
+    assert.same("enum Color { Red, Green, Blue }", lines.get_line(49))
     tw.swap_left()
-    assert.same('enum Color { Green, Red, Blue }', lines.get_line(49))
+    assert.same("enum Color { Green, Red, Blue }", lines.get_line(49))
     h.assert_cursor_at(49, 14, "Red")
   end)
 
@@ -44,5 +44,3 @@ describe("In a rust file:", function()
     assert.same('    println!(calculate_area(shape), "shape_area");', lines.get_line(46))
   end)
 end)
-
-

--- a/tests/treewalker/typescript_spec.lua
+++ b/tests/treewalker/typescript_spec.lua
@@ -1,8 +1,8 @@
-local load_fixture = require "tests.load_fixture"
-local assert = require "luassert"
-local tw = require 'treewalker'
-local lines = require 'treewalker.lines'
-local h = require 'tests.treewalker.helpers'
+local load_fixture = require("tests.load_fixture")
+local assert = require("luassert")
+local tw = require("treewalker")
+local lines = require("treewalker.lines")
+local h = require("tests.treewalker.helpers")
 
 describe("Swapping in a typescript file:", function()
   before_each(function()
@@ -15,15 +15,15 @@ describe("Swapping in a typescript file:", function()
     vim.fn.cursor(106, 1) -- |  const i = 1
     tw.swap_down()
     h.assert_cursor_at(107, 3)
-    assert.same('  const j = 2', lines.get_line(106))
-    assert.same('  const i = 1', lines.get_line(107))
+    assert.same("  const j = 2", lines.get_line(106))
+    assert.same("  const i = 1", lines.get_line(107))
   end)
 
   it("swaps down annotated functions of different length", function()
     vim.fn.cursor(107, 1) -- |  const i = 1
     tw.swap_up()
     h.assert_cursor_at(106, 3)
-    assert.same('  const j = 2', lines.get_line(106))
-    assert.same('  const i = 1', lines.get_line(107))
+    assert.same("  const j = 2", lines.get_line(106))
+    assert.same("  const i = 1", lines.get_line(107))
   end)
 end)

--- a/tests/treewalker/util_spec.lua
+++ b/tests/treewalker/util_spec.lua
@@ -1,5 +1,5 @@
 local util = require("treewalker.util")
-local stub = require('luassert.stub')
+local stub = require("luassert.stub")
 local assert = require("luassert")
 
 describe("util", function()
@@ -39,14 +39,14 @@ describe("util", function()
         end,
         close = function()
           num_closes = num_closes + 1
-        end
+        end,
       }
 
       io_open_stub.returns(log_file)
 
       util.log(1, 2, 3, 4, 5)
 
-      assert.same({ "1\n", "2\n", "3\n", "4\n", "5\n", }, writes)
+      assert.same({ "1\n", "2\n", "3\n", "4\n", "5\n" }, writes)
       assert.equal(1, num_flushes)
       assert.equal(1, num_closes)
     end)


### PR DESCRIPTION
- Lua files were formatted using `stylua`, with the formatting defined in `stylua.toml`
- Two make targets were added: `check-fmt` which checks the formatting of lua files and `fmt` which formats the file
- Steps were added to the existing CI to check the formatting of the luafiles in the codebase.

This pr is similar to that filed in [GPTModels](https://github.com/aaronik/GPTModels.nvim/pull/9) 

Running CI locally fails with the following error:
```
 No handler for set-lang-from-info-string
```
This appears to be due to using a newer version of treesitter. I'll dig into this more, but the githiub CI may pass without additional changes needed.