### PR TITLE
Support movement across same-indent containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ test-watch: ## uses [nodemon](https://nodemon.io/) - watches for changes to lua 
 	@nodemon -e lua -x "$(MAKE) test || exit 1"
 
 test-ubuntu: ## Run tests in Ubuntu Docker container (matches CI environment)
-	@docker run --rm -v $$(PWD):/workspace -w /workspace ubuntu:latest bash -c "\
+	@docker run --rm -v $$(pwd):/workspace -w /workspace ubuntu:latest bash -c "\
 		apt-get update && \
 		apt-get install -y software-properties-common git curl make apt-utils gcc && \
 		add-apt-repository -y ppa:neovim-ppa/unstable && \

--- a/lua/treewalker/anchor.lua
+++ b/lua/treewalker/anchor.lua
@@ -303,6 +303,10 @@ local function has_same_indent_jump_ancestor(current, candidate)
         return parent ~= current.node
       end
 
+      if vim.treesitter.is_ancestor(iter, current.node) then
+        return false
+      end
+
       return true
     end
 
@@ -361,8 +365,16 @@ function M.find_in(current)
       local indent = lines.get_start_col(line)
       local candidate = M.at_row(row)
 
-      if indent > current.indent and candidate and classify.is_jump_target(candidate.node) then
-        return candidate
+      if candidate and classify.is_jump_target(candidate.node) then
+        if indent > current.indent then
+          return candidate
+        end
+
+        if indent == current.indent
+          and vim.treesitter.is_ancestor(current.node, candidate.node)
+        then
+          return candidate
+        end
       end
 
       if indent < current.indent and line ~= "" then
@@ -383,12 +395,20 @@ function M.find_out(current)
     current = M.find_down(current) or current
   end
 
+  local fallback = nil ---@type TSNode | nil
   local iter = current.node:parent()
   while iter do
-    if classify.is_jump_target(iter) and not nodes.have_same_scol(current.node, iter) then
-      return build_anchor(iter, nodes.get_srow(iter))
+    if classify.is_jump_target(iter) then
+      if not nodes.have_same_scol(current.node, iter) then
+        return build_anchor(iter, nodes.get_srow(iter))
+      end
+      fallback = iter
     end
     iter = iter:parent()
+  end
+
+  if fallback then
+    return build_anchor(fallback, nodes.get_srow(fallback))
   end
 end
 

--- a/tests/fixtures/cpp.cpp
+++ b/tests/fixtures/cpp.cpp
@@ -1,0 +1,29 @@
+/*
+   Notice the lack of indentation inside the namespace.
+   This style is used in for example the Google style guide,
+   https://google.github.io/styleguide/cppguide.html#Namespaces
+*/
+namespace foo
+{
+struct A
+{
+    double x;
+};
+
+struct B
+{
+    double y;
+};
+
+struct C
+{
+    double z;
+};
+
+constexpr void bar(const A& a, const B& b, const C& c)
+{
+    // Do something with a, b, and c
+}
+}
+
+

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -21,6 +21,7 @@ ts_config.setup {
   ensure_installed = {
     "lua",
     "c",
+    "cpp",
     "python",
     "rust",
     "haskell",

--- a/tests/treewalker/cpp_spec.lua
+++ b/tests/treewalker/cpp_spec.lua
@@ -18,7 +18,7 @@ describe("In a C++ file:", function()
       tw.move_down()
       h.assert_cursor_at(18, 1) -- Should move to struct C.
       tw.move_in()
-      h.assert_cursor_at(20, 1) -- Should move into struct C to double z.
+      h.assert_cursor_at(20, 5) -- Should move into struct C to double z.
       tw.move_out()
       h.assert_cursor_at(18, 1) -- Should move back out to struct C
       tw.move_down()

--- a/tests/treewalker/cpp_spec.lua
+++ b/tests/treewalker/cpp_spec.lua
@@ -1,0 +1,35 @@
+local load_fixture = require "tests.load_fixture"
+local tw = require 'treewalker'
+local h = require 'tests.treewalker.helpers'
+
+describe("In a C++ file:", function()
+  before_each(function()
+    load_fixture("/cpp.cpp")
+  end)
+
+  h.ensure_has_parser("cpp")
+
+  it("moves around", function()
+      vim.fn.cursor(6, 1) -- At namespace foo.
+      tw.move_in()
+      h.assert_cursor_at(8, 1) -- Should move into namespace and land at struct A.
+      tw.move_down()
+      h.assert_cursor_at(13, 1) -- Should move to struct B.
+      tw.move_down()
+      h.assert_cursor_at(18, 1) -- Should move to struct C.
+      tw.move_in()
+      h.assert_cursor_at(20, 1) -- Should move into struct C to double z.
+      tw.move_out()
+      h.assert_cursor_at(18, 1) -- Should move back out to struct C
+      tw.move_down()
+      h.assert_cursor_at(23, 1) -- Should move to bar function.
+      tw.move_up()
+      h.assert_cursor_at(18, 1) -- Should move back to struct C.
+      tw.move_up()
+      h.assert_cursor_at(13, 1) -- Should move back to struct B.
+      tw.move_up()
+      h.assert_cursor_at(8, 1) -- Should move back to struct A.
+      tw.move_out()
+      h.assert_cursor_at(6, 1) -- Should move back out to namespace foo
+  end)
+end)


### PR DESCRIPTION
## Problem

Treewalker can't currently enter or move between siblings inside a container whose children share its indent, which I personally encounter in `.hpp` files when using `namespace` in C++ with formatting rules setting the indentation like
```C++
namespace foo
{
struct A
{
    double x;
};

struct B
{
    double y;
};

struct C
{
    double z;
};

constexpr void bar(const A& a, const B& b, const C& c)
{
}
}
```
Here, I am not able to jump between the structs.

## Solution
Use the treesitter tree as a fallback when indentation is not enough. Changes in `anchor.lua` to `find_in`, `has_same_indent_jump_ancestor`, and `find_out`, where each adds a tree-relationship branch alongside the existing indent heuristics.

Additional fix in the `Makefile` `$$(PWD` -> `$$(pwd)`, due to expansion bug

## Testing
Added a specific cpp test file that tests the desired behavior through various movements.
